### PR TITLE
healthd: BatteryMonitor: Fix compiler warning

### DIFF
--- a/healthd/BatteryMonitor.cpp
+++ b/healthd/BatteryMonitor.cpp
@@ -243,7 +243,6 @@ bool BatteryMonitor::update(void) {
     if (readFromFile(mHealthdConfig->batteryTechnologyPath, &buf) > 0)
         props.batteryTechnology = String8(buf.c_str());
 
-    unsigned int i;
     double MaxPower = 0;
 
     // Rescan for the available charger types
@@ -280,7 +279,7 @@ bool BatteryMonitor::update(void) {
         }
     }
 
-    for (i = 0; i < mChargerNames.size(); i++) {
+    for (size_t i = 0; i < mChargerNames.size(); i++) {
         String8 path;
         path.appendFormat("%s/%s/online", POWER_SUPPLY_SYSFS_PATH,
                           mChargerNames[i].string());


### PR DESCRIPTION
system/core/healthd/BatteryMonitor.cpp:248:19: note: initialize the variable 'i' to silence this warning
    unsigned int i;
                  ^
                   = 0
1 warning generated.

Change-Id: Ib2fa0061d657fd93871ca8a9056d173d5b7ab58d