### PR TITLE
adbd: Disable "adb root" by system property

### DIFF
--- a/adb/services.cpp
+++ b/adb/services.cpp
@@ -84,6 +84,16 @@ void restart_root_service(int fd, void *cookie) {
             return;
         }
 
+        int root_access = android::base::GetIntProperty("persist.sys.root_access", 0);
+        std::string build_type = android::base::GetProperty("ro.build.type", "");
+
+        if (build_type != "eng" && (root_access & 2) != 2) {
+            WriteFdExactly(fd, "root access is disabled by system setting - "
+                    "enable in Settings -> System -> Developer options\n");
+            adb_close(fd);
+            return;
+        }
+
         android::base::SetProperty("lineage.service.adb.root", "1");
         WriteFdExactly(fd, "restarting adbd as root\n");
         adb_close(fd);


### PR DESCRIPTION
Author: Steve Kondik <shade@chemlab.org>
Date:   Sat Jan 14 17:04:22 2012 -0800

    adbd: Disable "adb root" by system property (2/3)

     * Require persist.sys.root_access=1 on non-eng debuggable builds

    Change-Id: Iedab030e81ffb525fed64aed80cf0014f3e07073

Author: Steve Kondik <steve@cyngn.com>
Date:   Sun Oct 18 02:07:16 2015 -0700

    adb: Fix compilation issue

    Change-Id: Ia3284d5b8e428474726f64231f8142cf2474b17f

Author: Michael Bestas <mkbestas@lineageos.org>
Date:   Thu Feb 1 17:04:45 2018 +0000
Edit:   Adapt for O and rebrand prop

Author: Bruno Martins <bgcngm@gmail.com>
Date:   Sat Nov 17 15:30:45 2018 +0000
Edit:   Remove useless Lineage prop check

Change-Id: Ib880967a72296edfb05b80875fbe18136338a8c5