### PR TITLE
reboot: only run fsck when detecting filesystem inconsistency

### DIFF
--- a/init/reboot.cpp
+++ b/init/reboot.cpp
@@ -105,13 +105,17 @@ class MountEntry {
         int st;
         if (IsF2Fs()) {
             const char* f2fs_argv[] = {
-                "/system/bin/fsck.f2fs", "-f", mnt_fsname_.c_str(),
+                    "/system/bin/fsck.f2fs",
+                    "-a",
+                    mnt_fsname_.c_str(),
             };
             android_fork_execvp_ext(arraysize(f2fs_argv), (char**)f2fs_argv, &st, true, LOG_KLOG,
                                     true, nullptr, nullptr, 0);
         } else if (IsExt4()) {
             const char* ext4_argv[] = {
-                "/system/bin/e2fsck", "-f", "-y", mnt_fsname_.c_str(),
+                    "/system/bin/e2fsck",
+                    "-y",
+                    mnt_fsname_.c_str(),
             };
             android_fork_execvp_ext(arraysize(ext4_argv), (char**)ext4_argv, &st, true, LOG_KLOG,
                                     true, nullptr, nullptr, 0);


### PR DESCRIPTION
Running fsck when filesystem is in clean state is unnecessary
and causes long shutdown duration.

Bug: 120575926
Test: shutdown
Change-Id: I0562bdad4ac2fb2dd3c9617f96ca3d6279876bd8
Signed-off-by: Randall Huang <huangrandall@google.com>